### PR TITLE
Switched BeatLeader links to .com

### DIFF
--- a/MapMaven.Core/Services/Leaderboards/LeaderboardService.cs
+++ b/MapMaven.Core/Services/Leaderboards/LeaderboardService.cs
@@ -31,7 +31,7 @@ namespace MapMaven.Core.Services.Leaderboards
         public string? PlayerId => _activeLeaderboardProviderName.Value is not null ? LeaderboardProviders[_activeLeaderboardProviderName.Value].PlayerId : null;
         public LeaderboardProvider? ActiveLeaderboardProviderNameValue => _activeLeaderboardProviderName.Value;
 
-        public const string ReplayBaseUrl = "https://replay.beatleader.xyz";
+        public const string ReplayBaseUrl = "https://replay.beatleader.com";
 
         public LeaderboardService(
             IEnumerable<ILeaderboardProviderService> leaderboardProviders,

--- a/MapMaven.DataGatherers.BeatLeader/Program.cs
+++ b/MapMaven.DataGatherers.BeatLeader/Program.cs
@@ -12,7 +12,7 @@ IHost host = Host.CreateDefaultBuilder(args)
             contextLifetime: ServiceLifetime.Singleton
         );
 
-        services.AddHttpClient<BeatLeaderApiClient>(client => client.BaseAddress = new Uri("https://api.beatleader.xyz"));
+        services.AddHttpClient<BeatLeaderApiClient>(client => client.BaseAddress = new Uri("https://api.beatleader.com"));
     })
     .Build();
 

--- a/MapMaven.Infrastructure/StartupSetup.cs
+++ b/MapMaven.Infrastructure/StartupSetup.cs
@@ -41,7 +41,7 @@ namespace MapMaven.Infrastructure
             services.AddScoped(_ => new BeatSaver("MapMaven", new Version(1, 0)));
 
             services.AddHttpClient<ScoreSaberApiClient>(client => client.BaseAddress = new Uri("https://scoresaber.com"));
-            services.AddHttpClient<BeatLeaderApiClient>(client => client.BaseAddress = new Uri("https://api.beatleader.xyz"));
+            services.AddHttpClient<BeatLeaderApiClient>(client => client.BaseAddress = new Uri("https://api.beatleader.com"));
             services.AddHttpClient<BeatSaverApiClient>(client => client.BaseAddress = new Uri("https://api.beatsaver.com"));
             services.AddHttpClient("GithubApi", client =>
             {

--- a/MapMaven/Components/PlayerProfileInfo.razor
+++ b/MapMaven/Components/PlayerProfileInfo.razor
@@ -4,7 +4,7 @@
     var profileUrl = Player.LeaderboardProvider switch
     {
         LeaderboardProvider.ScoreSaber => $"https://scoresaber.com/u/{Player.Id}",
-        LeaderboardProvider.BeatLeader => $"https://www.beatleader.xyz/u/{Player.Id}",
+        LeaderboardProvider.BeatLeader => $"https://beatleader.com/u/{Player.Id}",
     };
 
     <div class="d-flex pa-2 profile full-width">

--- a/MapMaven/Components/Settings.razor.cs
+++ b/MapMaven/Components/Settings.razor.cs
@@ -16,7 +16,7 @@ namespace MapMaven.Components
     public partial class Settings
     {
         private static readonly Regex _scoreSaberPlayerIdUrlRegex = new Regex(@"scoresaber.com\/u\/(?<playerId>[^\/\?]+)");
-        private static readonly Regex _beatLeaderPlayerIdUrlRegex = new Regex(@"beatleader.xyz\/u\/(?<playerId>[^\/\?]+)");
+        private static readonly Regex _beatLeaderPlayerIdUrlRegex = new Regex(@"beatleader.com\/u\/(?<playerId>[^\/\?]+)");
 
         [Inject]
         protected IFolderPicker FolderPicker { get; set; }


### PR DESCRIPTION
We moved from .xyz domain because of the DNS issues in the US. The main website auto redirects to .com so there is no need for backward compatibility.